### PR TITLE
Switch from 'endnotes' package to 'enotez'.

### DIFF
--- a/mcmc.tex
+++ b/mcmc.tex
@@ -42,7 +42,7 @@
 % - Should we use the word ``walker'' everywhere and do we?
 
 \documentclass[12pt,twoside,pdftex]{article}
-\usepackage{styles/dar_endnotes}
+\usepackage[backref=true]{enotez}
 
 \newcommand{\chaptertitle}{Using Markov Chain Monte Carlo}
 \include{styles/dar}
@@ -54,6 +54,16 @@
 \newcommand{\pars}{\theta}
 \newcommand{\best}{{\mathrm{(best)}}}
 \newcommand{\better}{{\mathrm{(better)}}}
+
+\let\note=\endnote
+
+\DeclareInstance{enotez-list}{custom}{paragraph}
+{
+  number = \makebox[0pt][r]{\textsuperscript{#1}},
+  format = \indent\normalfont,
+  number-format = \bfseries,
+}
+
 
 \begin{document}\sloppy\sloppypar\raggedbottom\thispagestyle{plain}%
 %
@@ -2170,7 +2180,7 @@ about what changes to make or what new directions to explore.
 %% sample a posterior pdf!
 
 \clearpage
-\markright{Notes}\theendnotes
+\markright{Notes}\printendnotes[custom]
 
 \clearpage
 \raggedright


### PR DESCRIPTION
If you like the result and if you can use the 'enotez' package maybe this pull solves your "Would love to have the Note symbols to be links to the notes and the notes to have links back to the main text...!" todo item.